### PR TITLE
20240826 日報メンション機能実装

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -63,7 +63,7 @@ class ReportsController < ApplicationController
     report.report_mentions_as_mentioning.destroy_all
     mentioned_report_ids = Report.extract_mentioned_report_ids(report.content).uniq
     mentioned_report_ids.each do |mentioned_report_id|
-      ReportMention.create(mentioning_report_id: report.id, mentioned_report_id: mentioned_report_id)
+      ReportMention.create(mentioning_report_id: report.id, mentioned_report_id:)
     end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,6 +22,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     if @report.save
+      create_mentions(@report)
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -30,6 +31,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
+      create_mentions(@report)
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity
@@ -38,7 +40,6 @@ class ReportsController < ApplicationController
 
   def destroy
     @report.destroy
-
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   end
 
@@ -50,5 +51,17 @@ class ReportsController < ApplicationController
 
   def report_params
     params.require(:report).permit(:title, :content)
+  end
+
+  def create_mentions(report)
+    report.report_mentions_as_mentioning.destroy_all
+    mentioned_report_ids = extract_mentioned_report_ids(report.content)
+    mentioned_report_ids.each do |mentioned_report_id|
+      ReportMention.create(mentioning_report_id: report.id, mentioned_report_id:)
+    end
+  end
+
+  def extract_mentioned_report_ids(content)
+    content.scan(%r{http://localhost:3000/reports/(\d+)}).flatten.map(&:to_i)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -18,4 +18,8 @@ class Report < ApplicationRecord
   def created_on
     created_at.to_date
   end
+
+  def self.extract_mentioned_report_ids(content)
+    content.scan(%r{http://localhost:3000/reports/(\d+)}).flatten.map(&:to_i)
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,6 +3,10 @@
 class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
+  has_many :report_mentions_as_mentioning, class_name: 'ReportMention', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
+  has_many :mentioning_reports, through: :report_mentions_as_mentioning, source: :mentioned_report
+  has_many :report_mentions_as_mentioned, class_name: 'ReportMention', foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
+  has_many :mentioned_reports, through: :report_mentions_as_mentioned, source: :mentioning_report
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,6 +11,8 @@ class Report < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
 
+  REPORT_ID_URL = %r{http://localhost:3000/reports/(\d+)}
+
   def editable?(target_user)
     user == target_user
   end
@@ -19,7 +21,11 @@ class Report < ApplicationRecord
     created_at.to_date
   end
 
-  def self.extract_mentioned_report_ids(content)
-    content.scan(%r{http://localhost:3000/reports/(\d+)}).flatten.map(&:to_i)
+  def create_mentions
+    report_mentions_as_mentioning.destroy_all
+    mentioned_report_ids = content.scan(REPORT_ID_URL).flatten.map(&:to_i).uniq
+    mentioned_report_ids.each do |mentioned_report_id|
+      ReportMention.create(mentioning_report_id: id, mentioned_report_id:)
+    end
   end
 end

--- a/app/models/report_mention.rb
+++ b/app/models/report_mention.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ReportMention < ApplicationRecord
+  belongs_to :mentioning_report, class_name: 'Report'
+  belongs_to :mentioned_report, class_name: 'Report'
+end

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -4,7 +4,7 @@
   <%= render @report %>
 </div>
 
-<h3><%= t('activerecord.attributes.report.mentioned_reports') %></h3>
+<h3><%= t('views.reports.show.mentioned_reports') %></h3>
 <ul>
   <% @report.mentioned_reports.each do |report| %>
     <li><%= link_to report.title, report_path(report) %></li>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -4,6 +4,13 @@
   <%= render @report %>
 </div>
 
+<h3><%= t('activerecord.attributes.report.mentioned_reports') %></h3>
+<ul>
+  <% @report.mentioned_reports.each do |report| %>
+    <li><%= link_to report.title, report_path(report) %></li>
+  <% end %>
+</ul>
+
 <%= render 'shared/comments', commentable: @report %>
 
 <nav class="page-nav">

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -4,7 +4,7 @@
   <%= render @report %>
 </div>
 
-<h3><%= t('views.reports.show.mentioned_reports') %></h3>
+<h3><%= t('.mentioned_reports') %></h3>
 <ul>
   <% @report.mentioned_reports.each do |report| %>
     <li><%= link_to report.title, report_path(report) %></li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -202,9 +202,9 @@ ja:
       previous: '‹ 前'
       next: '次 ›'
       truncate: '…'
-    reports:
-      show:
-        mentioned_reports: この記事は以下の記事からリンクされています
+  reports:
+    show:
+      mentioned_reports: この記事は以下の記事からリンクされています
   controllers:
     common:
       notice_create: "%{name}が作成されました。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -202,6 +202,9 @@ ja:
       previous: '‹ 前'
       next: '次 ›'
       truncate: '…'
+    reports:
+      show:
+        mentioned_reports: この記事は以下の記事からリンクされています
   controllers:
     common:
       notice_create: "%{name}が作成されました。"

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -23,3 +23,4 @@ ja:
         content: 内容
         user: 作成者
         created_on: 作成日
+        mentioned_reports: この記事は以下の記事からリンクされています

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -23,4 +23,3 @@ ja:
         content: 内容
         user: 作成者
         created_on: 作成日
-        mentioned_reports: この記事は以下の記事からリンクされています

--- a/db/migrate/20240826060236_create_report_mentions.rb
+++ b/db/migrate/20240826060236_create_report_mentions.rb
@@ -1,0 +1,12 @@
+class CreateReportMentions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :report_mentions do |t|
+      t.references :mentioning_report, null: false, foreign_key: { to_table: :reports }
+      t.references :mentioned_report, null: false, foreign_key: { to_table: :reports }
+
+      t.timestamps
+    end
+
+    add_index :report_mentions, [:mentioning_report_id, :mentioned_report_id], unique: true, name: 'index_report_mentions'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_26_060236) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,6 +59,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "report_mentions", force: :cascade do |t|
+    t.integer "mentioning_report_id", null: false
+    t.integer "mentioned_report_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mentioned_report_id"], name: "index_report_mentions_on_mentioned_report_id"
+    t.index ["mentioning_report_id", "mentioned_report_id"], name: "index_report_mentions", unique: true
+    t.index ["mentioning_report_id"], name: "index_report_mentions_on_mentioning_report_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
@@ -87,5 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "report_mentions", "reports", column: "mentioned_report_id"
+  add_foreign_key "report_mentions", "reports", column: "mentioning_report_id"
   add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
## プラクティス
[日報の言及機能を作る](https://bootcamp.fjord.jp/practices/256)

## 実装したこと
- [x] 中間テーブルの作成
- [x] モデル間を適切に関連付け
- [x] 日報のコントローラ内でメンションのデータを操作する処理
- [x] 日報詳細画面にメンションされている日報を一覧表示
- [x] 日本語対応

## メンション機能動作一連の流れ 
### メンション先の日報
http://localhost:3000/reports/55
![image](https://github.com/user-attachments/assets/ca4c2844-1b9e-4a18-8e82-702236517890)

### 日報作成
http://localhost:3000/reports/55を本文中に入れて作成
![image](https://github.com/user-attachments/assets/a25e8f7c-5c76-4273-99b0-ed62513cf687)

### メンション先(55番の日報)の日報詳細ページ
「この記事は以下の記事からリンクされています」の文言の下に先ほど作った日報のタイトルがリンク化されて表示されていることがわかります。
![image](https://github.com/user-attachments/assets/a52121fb-a2b5-427d-8435-c21943311146)

### 作成した日報を更新
55番の日報に加えて54番の日報についても本文中に入れる
![image](https://github.com/user-attachments/assets/b65bac3c-855f-4306-980c-9224b48fcad1)

### メンション先(54番の日報)の日報詳細ページ
「この記事は以下の記事からリンクされています」の文言の下に先ほど作った日報のタイトルがリンク化されて表示されていることがわかります。
![image](https://github.com/user-attachments/assets/f0e484ba-20ab-4ba7-a80d-a4b27cc02216)

### メンション削除
日報の本文中に書いてあったリンクを削除して更新
![image](https://github.com/user-attachments/assets/dd2e80d9-7f0d-4f46-afc0-e7318980e7ee)

### 削除後の54・55番の日報詳細ページ
![image](https://github.com/user-attachments/assets/2903c7fc-6d11-4c53-b161-33820e5ecf83)
![image](https://github.com/user-attachments/assets/177bb599-15fd-45b6-b3fa-f1844fe7922e)

## rubocop実行結果
```
chiroru@MacBook-Pro-3 fjord-books_app-2023 % rubocop
Inspecting 36 files
....................................

36 files inspected, no offenses detected
```

### erblint実行結果
```
Linting and autocorrecting 30 files with 13 linters (10 autocorrectable)...

No errors were found in ERB files
```